### PR TITLE
Accomodate newer log entry format in llogcolor

### DIFF
--- a/scripts/llogcolor
+++ b/scripts/llogcolor
@@ -62,9 +62,9 @@ colors =  { 'default'       :    "\033[0m",
             'on_cyan'       :    "\033[46m",
             'on_white'      :    "\033[47m" }
 
-# Exmple line from a lustre log:
-# 00000020:00000080:2:1192055998.876285:0:6848:0:(obd_config.c:714:class_process_config()) processing cmd: cf003
-pattern = re.compile(r'(?P<begin>    \d+:\d+:\d+:)'
+# Example line from a lustre log:
+# 00000020:00000080:2.0:1192055998.876285:0:6848:0:(obd_config.c:714:class_process_config()) processing cmd: cf003
+pattern = re.compile(r'(?P<begin>    \d+:\d+:\d+(\.\d+)?:)'
                      '(?P<timestamp> \d+\.\d+)'
                      '(?P<middle>    :\d+:)'
                      '(?P<threadid>  \d+)'


### PR DESCRIPTION
```
Log entries in Lustre 2 added a fractional part to the third numeric
field.  Update the regex to accomodate the change.
```
