### PR TITLE
b=1110 Don't follow symlinks in purge function.

### DIFF
--- a/src/lpurge.c
+++ b/src/lpurge.c
@@ -561,7 +561,7 @@ purge(const char *path, time_t thresh, struct elist_struct *elist,
                 if (dp->d_type == DT_DIR) {
                         is_dir = 1;
                 } else if (dp->d_type == DT_UNKNOWN) {
-                        if (stat(fqp, &s) != 0) {
+                        if (lstat(fqp, &s) != 0) {
                                 fprintf(stderr, "%s: could not stat %s\n",
                                         prog, fqp);
                                 return 0;


### PR DESCRIPTION
The purge function should not follow symlinks when they are encountered,
thus the stat call in that function was replaced with a call to lstat.
