### PR TITLE
Leave terminal in sane state

### DIFF
--- a/scripts/llogcolor
+++ b/scripts/llogcolor
@@ -27,6 +27,8 @@ import os
 import re
 import sys
 import subprocess
+import signal
+import errno
 
 colors =  { 'default'       :    "\033[0m",
             'bold'          :    "\033[1m",
@@ -119,7 +121,7 @@ def main():
         pager = None
         pass
     elif options.pager:
-        pager = subprocess.Popen(['less', '-XRS'], stdin=subprocess.PIPE)
+        pager = subprocess.Popen(['less', '-KXRS'], stdin=subprocess.PIPE)
         output = pager.stdin
     else:
         pager = None
@@ -128,34 +130,45 @@ def main():
     # Loop over all of the lines in the log
     thread_color = {}
     thread_file = {}
-    for line in fileinput.input(files=args):
-        result = pattern.match(line)
-        if not result:
-            output.write(line)
-            continue
+    try:
+        for line in fileinput.input(files=args):
+            result = pattern.match(line)
+            if not result:
+                output.write(line)
+                continue
 
-        tid = result.group('threadid')
-        ts = result.group('timestamp')
+            tid = result.group('threadid')
+            ts = result.group('timestamp')
 
-        if tid not in thread_color:
-            if not options.color:
-                thread_color[tid] = ''
-            elif tid == options.thread:
-                thread_color[tid] = colors['black'] + colors['on_cyan']
+            if tid not in thread_color:
+                if not options.color:
+                    thread_color[tid] = ''
+                elif tid == options.thread:
+                    thread_color[tid] = colors['black'] + colors['on_cyan']
+                else:
+                    thread_color[tid] = next_ansi_color()
+                if options.split:
+                    thread_file[tid] = open(os.path.join(split_dir, tid), 'w')
+
+            if options.date:
+                ts = str(datetime.datetime.fromtimestamp(float(ts)))
+                line = thread_color[tid] + ts + ' ' + result.group('begin') + result.group('middle') + tid + result.group('end') + '\n'
             else:
-                thread_color[tid] = next_ansi_color()
+                line = thread_color[tid] + result.group('begin') + ts + result.group('middle') + tid + result.group('end') + '\n'
+
+            output.write(line)
             if options.split:
-                thread_file[tid] = open(os.path.join(split_dir, tid), 'w')
-
-        if options.date:
-            ts = str(datetime.datetime.fromtimestamp(float(ts)))
-            line = thread_color[tid] + ts + ' ' + result.group('begin') + result.group('middle') + tid + result.group('end') + '\n'
-        else:
-            line = thread_color[tid] + result.group('begin') + ts + result.group('middle') + tid + result.group('end') + '\n'
-
-        output.write(line)
-        if options.split:
-            thread_file[tid].write(line)
+                thread_file[tid].write(line)
+    except KeyboardInterrupt:
+        if pager:
+            pager.send_signal(signal.SIGINT)
+        return 1
+    except IOError as (num, strerror):
+        if pager:
+            pager.kill()
+        if num == errno.EPIPE: # Ignore "Broken pipe", user quit less
+            return 0
+        raise
 
     if options.color:
         output.write(colors['default'])
@@ -171,8 +184,11 @@ def main():
         filenames = [os.path.join(split_dir, str(x)) for x in filenames]
         filenames = [combined] + filenames
         if options.pager:
-            pager = subprocess.Popen(['less', '-R', '--force'] + filenames)
-            pager.wait()
+            try:
+                pager = subprocess.Popen(['less', '-RK', '--force'] + filenames)
+                pager.wait()
+            except KeyboardInterrupt:
+                pager.send_signal(signal.SIGINT)
             for f in filenames:
                 os.remove(f)
             os.rmdir(split_dir)

--- a/src/lpurge.c
+++ b/src/lpurge.c
@@ -223,7 +223,8 @@ main(int argc, char *argv[])
                 exit(1);
         }
         if (stat(purgepath, &sb) < 0) {
-                fprintf(stderr, "%s: cannot stat %s\n", prog, purgepath);
+                fprintf(stderr, "%s: cannot stat %s: %s\n", prog, purgepath,
+                        strerror(errno));
                 exit(1);
         }
         if (!S_ISDIR(sb.st_mode)) {
@@ -278,11 +279,13 @@ main(int argc, char *argv[])
 
         /* clean up */
         if (outf && fclose(outf) != 0) {
-                fprintf(stderr, "%s: error closing eligible log file\n", prog);
+                fprintf(stderr, "%s: error closing eligible log file: %s\n",
+                        prog, strerror(errno));
                 exit_val = 1;
         }
         if (tallyf && fclose(tallyf) != 0) {
-                fprintf(stderr, "%s: error closing inode-tally file\n", prog);
+                fprintf(stderr, "%s: error closing inode-tally file: %s\n",
+                        prog, strerror(errno));
                 exit_val = 1;
         }
         elist_destroy(elist);
@@ -409,8 +412,8 @@ elist_verify(struct elist_struct *elist, const char *purgepath)
                 if (!strncmp(elist->paths[i], purgepath, strlen(purgepath))) {
                         if (stat(elist->paths[i], &sb) < 0) {
                                 fprintf(stderr, "%s: cannot stat exclude"
-                                        " path: %s (aborting)\n",
-                                        prog, elist->paths[i]);
+                                        " path: %s: %s (aborting)\n",
+                                        prog, elist->paths[i], strerror(errno));
                                 exit(1);
                         }
                         if (!S_ISDIR(sb.st_mode)) {
@@ -555,7 +558,8 @@ purge(const char *path, time_t thresh, struct elist_struct *elist,
         if (elist_find(elist, path))
                 return 0;
         if (!(dir = opendir(path))) {
-                fprintf(stderr, "%s: could not open %s\n", prog, path);
+                fprintf(stderr, "%s: could not open %s: %s\n", prog, path,
+                        strerror(errno));
                 return 0;
         }
         while ((dp = readdir(dir)) && !interrupted) {
@@ -569,8 +573,8 @@ purge(const char *path, time_t thresh, struct elist_struct *elist,
                 s_ptr = NULL;
                 if (type == DT_UNKNOWN) {
                         if (lstat(fqp, &s) != 0) {
-                                fprintf(stderr, "%s: could not stat %s\n",
-                                        prog, fqp);
+                                fprintf(stderr, "%s: could not stat %s: %s\n",
+                                        prog, fqp, strerror(errno));
                                 free(fqp);
                                 break;
                         }


### PR DESCRIPTION
If less is not given an opportunity to exit gracefully it can leave the
terminal settings in a bad state, for example with character echo
disabled.  The two common cases where this happens are with IOError and
KeyboardInterrupt exceptions.  In the former case just killing the pager
process in the exception handler seems to be sufficient.  On the other
hand, the only way I found to handle keyboard interrupt correctly in all
cases was to forward the SIGINT to less and exit.  This requires using
-K to make less exit on SIGINT.  This means you can't interrupt line
number calculating with Control-C and still remain within less, but this
seemed like a reasonable compromise.