### PR TITLE
ldev2cib: make skip_pattern compatible with python-2.6.6 and 2.7.5

### DIFF
--- a/scripts/ldev2cib
+++ b/scripts/ldev2cib
@@ -104,7 +104,7 @@ def record_xml(nodes, lustre_service_name, zfs_dataset):
 '      <rsc_colocation id="'+lustre_service_name+'_colocation" rsc="'+lustre_service_name+'" with-rsc="'+zpool+'" score="INFINITY"/>\n'
 
 
-skip_pattern = re.compile('^(\s*)?(#.*)?\n?$')
+skip_pattern = re.compile('^(\s*)(#.*)?\n?$')
 def should_skip(line):
     """Returns true is the line contains only a comment or whitespace"""
     if skip_pattern.match(line):


### PR DESCRIPTION
With python-2.6.6 and 2.7.5, skip_pattern fails to compile:

Traceback (most recent call last):
  File "./ldev2cib", line 107, in <module>
    skip_pattern = re.compile('^(\s*)?(#.*)?\n?$')
  File "/usr/lib64/python2.6/re.py", line 190, in compile
    return _compile(pattern, flags)
  File "/usr/lib64/python2.6/re.py", line 245, in _compile
    raise error, v # invalid expression
sre_constants.error: nothing to repeat

The ? after group (\s*) is what triggers the error.  Since the
group successfully matches both the emptry string and one or more
space characters, without the ?, the ? is unnecessary.  This
patch removes it.