### PR TITLE
add llogcolor to rpm

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,4 +1,4 @@
-dist_sbin_SCRIPTS = lflush lustre_quota_summary zfsobj2fid ldev2cib
+dist_sbin_SCRIPTS = lflush lustre_quota_summary zfsobj2fid ldev2cib llogcolor
 
 resourceagentdir = ${prefix}/lib/ocf/resource.d/llnl
 dist_resourceagent_SCRIPTS = lustre zpool


### PR DESCRIPTION
Add llogcolor to rpm - put it in /usr/sbin with lpurge, lflush, ldev2cib, et al.