### PR TITLE
Remove --local argument to pcs setup

### DIFF
--- a/scripts/ldev2pcs
+++ b/scripts/ldev2pcs
@@ -102,7 +102,7 @@ def configure_location(resource, nodes, fixed_score_string=None):
             score -= 10
 
 def configure():
-    cmd = 'pcs cluster setup --force --local'
+    cmd = 'pcs cluster setup --force'
     cmd += ' --name '+cmdline_args.cluster_name
     cmd += ' '+cmdline_args.mgmt_node
     run(cmd)


### PR DESCRIPTION
The --local argument causes pcs setup to remove /etc/pacemaker/authkey.
On non-RHEL distributions, with certain arguments, 'pcs setup' will
create a new authkey and distribute it to the other pacemaker nodes.
It does not apply in our case, and removing the authkey interferes
with our cluster configuration via cfengine.