### PR TITLE
Alter lflush to issue clear to servers in parallel

### DIFF
--- a/scripts/lflush
+++ b/scripts/lflush
@@ -63,16 +63,19 @@ flush_locks()
     local server count
 
     pushd ${nsdir} >/dev/null || die "could not chdir to ${nsdir}"
+        waiting=""
         for server in *; do
             [ "${server}" = "*" ] && die "could not find any servers"
             if ! lock_count ${server}; then
                 [ ${vopt} = 1 ] && warn "flushing ${server}"
-                if ! echo clear >${server}/lru_size; then
-                    warn "problem flushing ${server}"
-                    retval=1
-                fi
+                echo clear >${server}/lru_size &
+                child=$!
+                waiting="$waiting $child"
             fi
-	done
+        done
+        if ! wait $waiting; then
+            warn "problem flushing one or more servers; re-run with -v"
+        fi
     popd >/dev/null
 }
 


### PR DESCRIPTION
The shell command that triggers lustre to flush dirty pages and drop
ldlm locks,

        echo "clear" > {namespace-server-path-to-lru_size}

blocks until the process is complete.  Since separate servers are
designed to operate independently, the servers can be done in parallel.

To tide us over while we write a similar command in lustre itself, issue
these shell commands in parallel for each of the servers, and wait for
them to finish.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>