### PR TITLE
Look under /sys/fs/luste for namespaces

### DIFF
--- a/scripts/lflush
+++ b/scripts/lflush
@@ -25,7 +25,7 @@
 #
 # Based on flush-lustre-client-locks script by Herb Wartens.
 
-declare -r nsdir=/proc/fs/lustre/ldlm/namespaces
+declare nsdir
 declare -r prog=lflush
 
 vopt=0
@@ -85,7 +85,12 @@ flush_locks()
 
 [ $(id -u) = 0 ] || die "must run as root"
 
-if [ ! -d /proc/fs/lustre/ldlm/namespaces ]; then
+nsdir=/sys/fs/lustre/ldlm/namespaces
+if [ ! -d $nsdir ]; then
+	nsdir=/proc/fs/lustre/ldlm/namespaces
+fi
+
+if [ ! -d $nsdir ]; then
     warn "lustre client is not active - nothing to do"
     exit 0
 fi


### PR DESCRIPTION
Look under both /sys/fs/lustre/ldlm and /proc/fs/lustre/ldlm for namespaces.

Under Lustre 2.10, the the proc files that are used to flush locks were under /proc, at
/proc/fs/lustre/ldlm/namespaces/<MDT or OST>/lru_size.

Starting with Lustre 2.12, the files used for that purpose are under /sys, at
/sys/fs/lustre/ldlm/namespaces/<MDT or OST>/lru_size.
