### PR TITLE
Fix lpurge build against lustre >=2.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,10 @@ AS_IF([test "x$enable_dist" = "xno"], [
 AC_PROG_CC
 
 # Check for headers
-AC_CHECK_HEADERS([lustre/lustre_user.h], [],
+lustre_user=no
+AC_CHECK_HEADERS([linux/lustre/lustre_user.h], [lustre_user=linux], [])
+AC_CHECK_HEADERS([lustre/lustre_user.h], [lustre_user=lustre], [])
+AS_IF([test "x$lustre_user" = "xno"],
         [AC_MSG_ERROR([lustre header not found])])
 
 ]) dnl enable_dist


### PR DESCRIPTION
Lustre 2.12 changes result in the following build errors.

> lpurge.c: In function 'llapi_stat_mds':
> lpurge.c:617:43: error: invalid application of 'sizeof' to incomplete type 'struct lov_user_mds_data_v3'
>                                     sizeof(struct lov_user_mds_data_v3) +
>                                            ^
> lpurge.c:617:43: error: invalid application of 'sizeof' to incomplete type 'struct lov_user_mds_data_v3'
>                                     sizeof(struct lov_user_mds_data_v3) +
>                                            ^
> lpurge.c:620:57: error: 'struct lov_user_mds_data_v2' has no member named 'lmd_st'
>          lstat_t *ls = &((struct lov_user_mds_data *)buf)->lmd_st;
>                                                          ^

Modify configure.ac to detect whether the Lustre 2.12 header location
exists, linux/lustre/lustre_user.h.

Create a lustre 2.12-suitable version of llapi_stat_mds() which uses
lov_user_mds_data and expects to get back a lustre_statx structure
instead of an lstat one.  Determine which version of llapi_stat_mds() to
use based on the presence of the new header file.

The lustre_statx structure has times in a new format, statx_timestamp,
where the tv_sec is seconds since the epoch, as with time_t, but
which is 64 bits long to prevent year 2038 wrapping.

Before 2038, the time_t and statx_timestamp.tv_sec have the same value.
Since I do not expect lpurge to be around that long, copy those low
order bits into the existing atime, ctime, and mtime structure
members.

The relevant lustre change:
https://git.whamcloud.com/?p=fs/lustre-release.git;a=commit;h=6712478e79588e73e28c7ccac3afc7ac2368a4f3
https://jira.whamcloud.com/browse/LU-6401

Fixes #17

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>