### PR TITLE
Include <sys/sysmacros.h> in lpurge.c

### DIFF
--- a/src/lpurge.c
+++ b/src/lpurge.c
@@ -46,6 +46,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <signal.h>
+#include <sys/sysmacros.h>
 
 #include <lustre/lustre_user.h>
 


### PR DESCRIPTION
lpurge calls makedev() which is declared in sys/sysmacros.h.

On RHEL7 that symbol was declared implicitly because sys/types.h
includes sys/sysmacros.h.  This was changed with RHEL 8 and so
sysmacros.h must be exlicitly included.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>