### PR TITLE
run python scripts under python2

### DIFF
--- a/scripts/ldev2pcs
+++ b/scripts/ldev2pcs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import re

--- a/scripts/llogcolor
+++ b/scripts/llogcolor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2011, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/scripts/lustre_precreate
+++ b/scripts/lustre_precreate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2011, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/scripts/lustre_quota_summary
+++ b/scripts/lustre_quota_summary
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2011, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/scripts/osthistogram
+++ b/scripts/osthistogram
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2011, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/scripts/ostmapping
+++ b/scripts/ostmapping
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2011, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/scripts/zfsobj2fid
+++ b/scripts/zfsobj2fid
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2014, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.


### PR DESCRIPTION
The TOSS 4 build farm requires that for python scripts, the shebang must
explicitly call out python2 or python3.

These scripts were written when python 2.x was was was invoked by
running the command 'python', and have not been tested or ported to
python3.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>