### PR TITLE
Reformatted llogcolor with "black -S -l 79"

### DIFF
--- a/scripts/llogcolor
+++ b/scripts/llogcolor
@@ -30,57 +30,71 @@ import subprocess
 import signal
 import errno
 
-colors =  { 'default'       :    "\033[0m",
-            'bold'          :    "\033[1m",
-            'underline'     :    "\033[4m",
-            'blink'         :    "\033[5m",
-            'reverse'       :    "\033[7m",
-            'concealed'     :    "\033[8m",
-
-            'black'         :    "\033[30m", 
-            'red'           :    "\033[31m",
-            'green'         :    "\033[32m",
-            'yellow'        :    "\033[33m",
-            'blue'          :    "\033[34m",
-            'magenta'       :    "\033[35m",
-            'cyan'          :    "\033[36m",
-            'white'         :    "\033[37m",
-
-            'bright_black'  :    "\033[90m", 
-            'bright_red'    :    "\033[91m",
-            'bright_green'  :    "\033[92m",
-            'bright_yellow' :    "\033[93m",
-            'bright_blue'   :    "\033[94m",
-            'bright_magenta':    "\033[95m",
-            'bright_cyan'   :    "\033[96m",
-            'bright_white'  :    "\033[97m",
-
-            'on_black'      :    "\033[40m", 
-            'on_red'        :    "\033[41m",
-            'on_green'      :    "\033[42m",
-            'on_yellow'     :    "\033[43m",
-            'on_blue'       :    "\033[44m",
-            'on_magenta'    :    "\033[45m",
-            'on_cyan'       :    "\033[46m",
-            'on_white'      :    "\033[47m" }
+colors = {
+    'default': "\033[0m",
+    'bold': "\033[1m",
+    'underline': "\033[4m",
+    'blink': "\033[5m",
+    'reverse': "\033[7m",
+    'concealed': "\033[8m",
+    'black': "\033[30m",
+    'red': "\033[31m",
+    'green': "\033[32m",
+    'yellow': "\033[33m",
+    'blue': "\033[34m",
+    'magenta': "\033[35m",
+    'cyan': "\033[36m",
+    'white': "\033[37m",
+    'bright_black': "\033[90m",
+    'bright_red': "\033[91m",
+    'bright_green': "\033[92m",
+    'bright_yellow': "\033[93m",
+    'bright_blue': "\033[94m",
+    'bright_magenta': "\033[95m",
+    'bright_cyan': "\033[96m",
+    'bright_white': "\033[97m",
+    'on_black': "\033[40m",
+    'on_red': "\033[41m",
+    'on_green': "\033[42m",
+    'on_yellow': "\033[43m",
+    'on_blue': "\033[44m",
+    'on_magenta': "\033[45m",
+    'on_cyan': "\033[46m",
+    'on_white': "\033[47m",
+}
 
 # Example line from a lustre log:
 # 00000020:00000080:2.0F:1192055998.876285:0:6848:0:(obd_config.c:714:class_process_config()) processing cmd: cf003
-pattern = re.compile(r'(?P<begin>    \d+:\d+:\d+(\.\d+)?F?:)'
-                     '(?P<timestamp> \d+\.\d+)'
-                     '(?P<middle>    :\d+:)'
-                     '(?P<threadid>  \d+)'
-                     '(?P<end>       :.+)',
-                     re.VERBOSE)
+pattern = re.compile(
+    r'(?P<begin>    \d+:\d+:\d+(\.\d+)?F?:)'
+    '(?P<timestamp> \d+\.\d+)'
+    '(?P<middle>    :\d+:)'
+    '(?P<threadid>  \d+)'
+    '(?P<end>       :.+)',
+    re.VERBOSE,
+)
 
-color_round_robin = ['green', 'yellow', 'magenta', 'cyan', 'white', 'red',
-                     'bright_green', 'bright_yellow', 'bright_magenta',
-                     'bright_cyan', 'bright_white', 'bright_red']
+color_round_robin = [
+    'green',
+    'yellow',
+    'magenta',
+    'cyan',
+    'white',
+    'red',
+    'bright_green',
+    'bright_yellow',
+    'bright_magenta',
+    'bright_cyan',
+    'bright_white',
+    'bright_red',
+]
+
 
 def next_ansi_color():
     next_color = colors[color_round_robin[0]]
-    color_round_robin.append(color_round_robin.pop(0)) # rotate the list
+    color_round_robin.append(color_round_robin.pop(0))  # rotate the list
     return next_color
+
 
 usage = """usage: %prog [options] [log1] [log2] ... [logN]
 
@@ -90,19 +104,43 @@ By default, and if stdout is a tty, %prog calls the pager (less) to display
 the colorized log.
 """.strip()
 
+
 def main():
     # Parse command-line options
     p = optparse.OptionParser(usage=usage)
-    p.add_option('-d', '--date', action='store_true',
-                 help='convert date to human-readable form')
-    p.add_option('-s', '--split', action='store_true',
-                 help='create a separate file for each thread')
-    p.add_option('-t', '--thread', type='string', metavar='TID',
-                 help='highlight one thread in a unique color (black on cyan)')
-    p.add_option('-P', '--no-pager', action='store_false', dest='pager',
-                 help='disable the pager, just write to stdout')
-    p.add_option('-C', '--no-color', action='store_false', dest='color',
-                 help='disable all colorization')
+    p.add_option(
+        '-d',
+        '--date',
+        action='store_true',
+        help='convert date to human-readable form',
+    )
+    p.add_option(
+        '-s',
+        '--split',
+        action='store_true',
+        help='create a separate file for each thread',
+    )
+    p.add_option(
+        '-t',
+        '--thread',
+        type='string',
+        metavar='TID',
+        help='highlight one thread in a unique color (black on cyan)',
+    )
+    p.add_option(
+        '-P',
+        '--no-pager',
+        action='store_false',
+        dest='pager',
+        help='disable the pager, just write to stdout',
+    )
+    p.add_option(
+        '-C',
+        '--no-color',
+        action='store_false',
+        dest='color',
+        help='disable all colorization',
+    )
     p.set_defaults(color=True)
     p.set_defaults(pager=True)
     p.set_defaults(split=False)
@@ -152,9 +190,26 @@ def main():
 
             if options.date:
                 ts = str(datetime.datetime.fromtimestamp(float(ts)))
-                line = thread_color[tid] + ts + ' ' + result.group('begin') + result.group('middle') + tid + result.group('end') + '\n'
+                line = (
+                    thread_color[tid]
+                    + ts
+                    + ' '
+                    + result.group('begin')
+                    + result.group('middle')
+                    + tid
+                    + result.group('end')
+                    + '\n'
+                )
             else:
-                line = thread_color[tid] + result.group('begin') + ts + result.group('middle') + tid + result.group('end') + '\n'
+                line = (
+                    thread_color[tid]
+                    + result.group('begin')
+                    + ts
+                    + result.group('middle')
+                    + tid
+                    + result.group('end')
+                    + '\n'
+                )
 
             output.write(line)
             if options.split:
@@ -166,7 +221,7 @@ def main():
     except IOError as (num, strerror):
         if pager:
             pager.kill()
-        if num == errno.EPIPE: # Ignore "Broken pipe", user quit less
+        if num == errno.EPIPE:  # Ignore "Broken pipe", user quit less
             return 0
         raise
 
@@ -185,7 +240,9 @@ def main():
         filenames = [combined] + filenames
         if options.pager:
             try:
-                pager = subprocess.Popen(['less', '-RK', '--force'] + filenames)
+                pager = subprocess.Popen(
+                    ['less', '-RK', '--force'] + filenames
+                )
                 pager.wait()
             except KeyboardInterrupt:
                 pager.send_signal(signal.SIGINT)
@@ -197,5 +254,6 @@ def main():
     elif pager:
         pager.wait()
 
+
 if __name__ == '__main__':
-      sys.exit(main())
+    sys.exit(main())


### PR DESCRIPTION
This commit does a whole-file reformatting in a python3
style using the tool black, however the code is
semantically unchanged and is still python2.
This is a first step in porting to python3 and the
purpose is to separate most of the formatting changes
from the actual code changes.