### PR TITLE
Converted regex string to raw string

### DIFF
--- a/scripts/llogcolor
+++ b/scripts/llogcolor
@@ -66,11 +66,11 @@ colors = {
 # Example line from a lustre log:
 # 00000020:00000080:2.0F:1192055998.876285:0:6848:0:(obd_config.c:714:class_process_config()) processing cmd: cf003
 pattern = re.compile(
-    r"(?P<begin>    \d+:\d+:\d+(\.\d+)?F?:)"
-    "(?P<timestamp> \d+\.\d+)"
-    "(?P<middle>    :\d+:)"
-    "(?P<threadid>  \d+)"
-    "(?P<end>       :.+)",
+    r"(?P<begin>     \d+:\d+:\d+(\.\d+)?F?:)"
+    r"(?P<timestamp> \d+\.\d+)"
+    r"(?P<middle>    :\d+:)"
+    r"(?P<threadid>  \d+)"
+    r"(?P<end>       :.+)",
     re.VERBOSE,
 )
 


### PR DESCRIPTION
A string used for a regex was represented
as the concatenation of several strings on
different lines, however, only the first was
prefixed with an "r". Consequently only the fist
part of the string was a raw string literal. This
commit makes all of the string literals for the
regex raw strings.