### PR TITLE
Converted from python2 to python3

### DIFF
--- a/scripts/llogcolor
+++ b/scripts/llogcolor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Copyright (c) 2011, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.
@@ -20,10 +20,10 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
+import argparse
 import datetime
 import errno
 import fileinput
-import optparse
 import os
 import re
 import signal
@@ -95,71 +95,74 @@ def next_ansi_color():
     color_round_robin.append(color_round_robin.pop(0))  # rotate the list
     return next_color
 
-
-usage = """usage: %prog [options] [log1] [log2] ... [logN]
-
-%prog accepts a lustre log on stdin or as a filename on the command line,
-and outputs a colorized version of the log.  Lines are colored by task id.
-By default, and if stdout is a tty, %prog calls the pager (less) to display
-the colorized log.
-""".strip()
-
+description = (
+    "Accepts a lustre log on stdin or as a filename on the command line, "
+    "and outputs a colorized version of the log. "
+    "Lines are colored by task id. By default, and if stdout is a tty, "
+    "the pager (less) is called to display the colorized log."
+)
 
 def main():
     # Parse command-line options
-    p = optparse.OptionParser(usage=usage)
-    p.add_option(
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
         "-d",
         "--date",
         action="store_true",
         help="convert date to human-readable form",
     )
-    p.add_option(
+    parser.add_argument(
         "-s",
         "--split",
         action="store_true",
         help="create a separate file for each thread",
     )
-    p.add_option(
+    parser.add_argument(
         "-t",
         "--thread",
-        type="string",
+        type=str,
         metavar="TID",
         help="highlight one thread in a unique color (black on cyan)",
     )
-    p.add_option(
+    parser.add_argument(
         "-P",
         "--no-pager",
         action="store_false",
         dest="pager",
         help="disable the pager, just write to stdout",
     )
-    p.add_option(
+    parser.add_argument(
         "-C",
         "--no-color",
         action="store_false",
         dest="color",
         help="disable all colorization",
     )
-    p.set_defaults(color=True)
-    p.set_defaults(pager=True)
-    p.set_defaults(split=False)
-    p.set_defaults(date=False)
-    options, args = p.parse_args()
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="the log files to be processed",
+    )
+
+    args = parser.parse_args()
 
     if not sys.stdout.isatty():
-        options.pager = False
+        args.pager = False
 
     split_dir = "/tmp/llogcolor.%d" % (os.getpid())
     combined = os.path.join(split_dir, "combined")
 
-    if options.split:
+    if args.split:
         os.mkdir(split_dir)
         output = open(combined, "w")
         pager = None
-        pass
-    elif options.pager:
-        pager = subprocess.Popen(["less", "-KXRS"], stdin=subprocess.PIPE)
+    elif args.pager:
+        # specify an encoding so the subprocess can accept strings
+        # (not bytes). This allows the output to the pager, files,
+        # and stdout, to all be the of same type (string).
+        pager = subprocess.Popen(
+            ["less", "-KXRS"], stdin=subprocess.PIPE, encoding="utf-8"
+        )
         output = pager.stdin
     else:
         pager = None
@@ -169,7 +172,7 @@ def main():
     thread_color = {}
     thread_file = {}
     try:
-        for line in fileinput.input(files=args):
+        for line in fileinput.input(files=args.files):
             result = pattern.match(line)
             if not result:
                 output.write(line)
@@ -179,16 +182,16 @@ def main():
             ts = result.group("timestamp")
 
             if tid not in thread_color:
-                if not options.color:
+                if not args.color:
                     thread_color[tid] = ""
-                elif tid == options.thread:
+                elif tid == args.thread:
                     thread_color[tid] = colors["black"] + colors["on_cyan"]
                 else:
                     thread_color[tid] = next_ansi_color()
-                if options.split:
+                if args.split:
                     thread_file[tid] = open(os.path.join(split_dir, tid), "w")
 
-            if options.date:
+            if args.date:
                 ts = str(datetime.datetime.fromtimestamp(float(ts)))
                 line = (
                     thread_color[tid]
@@ -212,33 +215,34 @@ def main():
                 )
 
             output.write(line)
-            if options.split:
+            if args.split:
                 thread_file[tid].write(line)
     except KeyboardInterrupt:
         if pager:
             pager.send_signal(signal.SIGINT)
         return 1
-    except IOError as (num, strerror):
+    except IOError as ioerror:
+        num, strerror = ioerror
         if pager:
             pager.kill()
         if num == errno.EPIPE:  # Ignore "Broken pipe", user quit less
             return 0
         raise
 
-    if options.color:
+    if args.color:
         output.write(colors["default"])
     output.close()
 
-    if options.split:
+    if args.split:
         for f in thread_file.values():
-            if options.color:
+            if args.color:
                 f.write(colors["default"])
             f.close()
         filenames = [int(x) for x in thread_file.keys()]
         filenames.sort()
         filenames = [os.path.join(split_dir, str(x)) for x in filenames]
         filenames = [combined] + filenames
-        if options.pager:
+        if args.pager:
             try:
                 pager = subprocess.Popen(
                     ["less", "-RK", "--force"] + filenames
@@ -250,7 +254,7 @@ def main():
                 os.remove(f)
             os.rmdir(split_dir)
         else:
-            print "Split log files are located in", split_dir
+            print(f"Split log files are located in {split_dir}")
     elif pager:
         pager.wait()
 


### PR DESCRIPTION
This commit changes the required python
interpreter from python2 to python3.

The deprecated optparse library is replaced with
the similar argparse library.

The python2 print keyword is replaced with the
print function.

A change was made so that all possible outputs
(less, the console, and files) are all opened so
that they accept strings (and not bytes). This is
due to python2 and python3 having differences in how
strings and bytes are handled.