### PR TITLE
Added testing for llogcolor

### DIFF
--- a/test/llogcolor_files/input-multi_tid-once
+++ b/test/llogcolor_files/input-multi_tid-once
@@ -1,0 +1,22 @@
+00040000:00000001:3.0F:1605658370.834898:0:5634:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834901:0:5636:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834902:0:5637:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834903:0:5638:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+00040000:00000001:3.0:1605658370.834904:0:5639:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+00040000:00000001:3.0:1605658370.834906:0:5640:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834909:0:5641:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:00000001:3.0:1605658370.834910:0:5642:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:04000000:3.0:1605658370.834911:0:5643:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834914:0:5644:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834914:0:5645:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5646:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5647:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834916:0:5648:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+00040000:00000001:3.0:1605658370.834916:0:5649:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+00040000:00000001:3.0:1605658370.834917:0:5650:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834918:0:5651:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:00000001:3.0:1605658370.834919:0:5652:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:04000000:3.0:1605658370.834920:0:5653:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834922:0:5654:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834922:0:5655:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)

--- a/test/llogcolor_files/input-multi_tid-twice
+++ b/test/llogcolor_files/input-multi_tid-twice
@@ -1,0 +1,44 @@
+00040000:00000001:3.0F:1605658370.834898:0:5634:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834901:0:5636:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834902:0:5637:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834903:0:5638:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+00040000:00000001:3.0:1605658370.834904:0:5639:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+00040000:00000001:3.0:1605658370.834906:0:5640:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834909:0:5641:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:00000001:3.0:1605658370.834910:0:5642:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:04000000:3.0:1605658370.834911:0:5643:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834914:0:5644:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834914:0:5645:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5646:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5647:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834916:0:5648:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+00040000:00000001:3.0:1605658370.834916:0:5649:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+00040000:00000001:3.0:1605658370.834917:0:5650:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834918:0:5651:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:00000001:3.0:1605658370.834919:0:5652:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:04000000:3.0:1605658370.834920:0:5653:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834922:0:5654:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834922:0:5655:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0F:1605658370.834898:0:5634:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834901:0:5636:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834902:0:5637:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834903:0:5638:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+00040000:00000001:3.0:1605658370.834904:0:5639:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+00040000:00000001:3.0:1605658370.834906:0:5640:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834909:0:5641:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:00000001:3.0:1605658370.834910:0:5642:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:04000000:3.0:1605658370.834911:0:5643:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834914:0:5644:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834914:0:5645:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5646:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5647:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834916:0:5648:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+00040000:00000001:3.0:1605658370.834916:0:5649:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+00040000:00000001:3.0:1605658370.834917:0:5650:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834918:0:5651:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:00000001:3.0:1605658370.834919:0:5652:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:04000000:3.0:1605658370.834920:0:5653:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834922:0:5654:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834922:0:5655:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)

--- a/test/llogcolor_files/input-single_tid-once
+++ b/test/llogcolor_files/input-single_tid-once
@@ -1,0 +1,22 @@
+00040000:00000001:3.0F:1605658370.834898:0:5635:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834901:0:5635:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834902:0:5635:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834903:0:5635:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+00040000:00000001:3.0:1605658370.834904:0:5635:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+00040000:00000001:3.0:1605658370.834906:0:5635:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834909:0:5635:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:00000001:3.0:1605658370.834910:0:5635:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+00040000:04000000:3.0:1605658370.834911:0:5635:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834914:0:5635:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834914:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5635:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+00040000:00000001:3.0:1605658370.834915:0:5635:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+00040000:04000000:3.0:1605658370.834916:0:5635:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+00040000:00000001:3.0:1605658370.834916:0:5635:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+00040000:00000001:3.0:1605658370.834917:0:5635:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+00040000:00000001:3.0:1605658370.834918:0:5635:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:00000001:3.0:1605658370.834919:0:5635:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+00040000:04000000:3.0:1605658370.834920:0:5635:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+00040000:00000001:3.0:1605658370.834922:0:5635:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+00040000:00000001:3.0:1605658370.834922:0:5635:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)

--- a/test/llogcolor_files/output-color-multi_tid-once
+++ b/test/llogcolor_files/output-color-multi_tid-once
@@ -1,0 +1,23 @@
+[32m00040000:00000001:3.0F:1605658370.834898:0:5634:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+[33m00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+[35m00040000:00000001:3.0:1605658370.834901:0:5636:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[36m00040000:00000001:3.0:1605658370.834902:0:5637:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[37m00040000:04000000:3.0:1605658370.834903:0:5638:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+[31m00040000:00000001:3.0:1605658370.834904:0:5639:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+[92m00040000:00000001:3.0:1605658370.834906:0:5640:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[93m00040000:00000001:3.0:1605658370.834909:0:5641:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[95m00040000:00000001:3.0:1605658370.834910:0:5642:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[96m00040000:04000000:3.0:1605658370.834911:0:5643:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+[97m00040000:00000001:3.0:1605658370.834914:0:5644:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[91m00040000:00000001:3.0:1605658370.834914:0:5645:0:(qmt_handler.c:56:qmt_get()) Process entered
+[32m00040000:00000001:3.0:1605658370.834915:0:5646:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[33m00040000:00000001:3.0:1605658370.834915:0:5647:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[35m00040000:04000000:3.0:1605658370.834916:0:5648:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+[36m00040000:00000001:3.0:1605658370.834916:0:5649:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+[37m00040000:00000001:3.0:1605658370.834917:0:5650:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[31m00040000:00000001:3.0:1605658370.834918:0:5651:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[92m00040000:00000001:3.0:1605658370.834919:0:5652:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[93m00040000:04000000:3.0:1605658370.834920:0:5653:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+[95m00040000:00000001:3.0:1605658370.834922:0:5654:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[96m00040000:00000001:3.0:1605658370.834922:0:5655:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)
+[0m

--- a/test/llogcolor_files/output-color-multi_tid-twice
+++ b/test/llogcolor_files/output-color-multi_tid-twice
@@ -1,0 +1,45 @@
+[32m00040000:00000001:3.0F:1605658370.834898:0:5634:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+[33m00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+[35m00040000:00000001:3.0:1605658370.834901:0:5636:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[36m00040000:00000001:3.0:1605658370.834902:0:5637:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[37m00040000:04000000:3.0:1605658370.834903:0:5638:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+[31m00040000:00000001:3.0:1605658370.834904:0:5639:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+[92m00040000:00000001:3.0:1605658370.834906:0:5640:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[93m00040000:00000001:3.0:1605658370.834909:0:5641:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[95m00040000:00000001:3.0:1605658370.834910:0:5642:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[96m00040000:04000000:3.0:1605658370.834911:0:5643:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+[97m00040000:00000001:3.0:1605658370.834914:0:5644:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[91m00040000:00000001:3.0:1605658370.834914:0:5645:0:(qmt_handler.c:56:qmt_get()) Process entered
+[32m00040000:00000001:3.0:1605658370.834915:0:5646:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[33m00040000:00000001:3.0:1605658370.834915:0:5647:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[35m00040000:04000000:3.0:1605658370.834916:0:5648:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+[36m00040000:00000001:3.0:1605658370.834916:0:5649:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+[37m00040000:00000001:3.0:1605658370.834917:0:5650:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[31m00040000:00000001:3.0:1605658370.834918:0:5651:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[92m00040000:00000001:3.0:1605658370.834919:0:5652:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[93m00040000:04000000:3.0:1605658370.834920:0:5653:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+[95m00040000:00000001:3.0:1605658370.834922:0:5654:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[96m00040000:00000001:3.0:1605658370.834922:0:5655:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)
+[32m00040000:00000001:3.0F:1605658370.834898:0:5634:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+[33m00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+[35m00040000:00000001:3.0:1605658370.834901:0:5636:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[36m00040000:00000001:3.0:1605658370.834902:0:5637:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[37m00040000:04000000:3.0:1605658370.834903:0:5638:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+[31m00040000:00000001:3.0:1605658370.834904:0:5639:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+[92m00040000:00000001:3.0:1605658370.834906:0:5640:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[93m00040000:00000001:3.0:1605658370.834909:0:5641:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[95m00040000:00000001:3.0:1605658370.834910:0:5642:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[96m00040000:04000000:3.0:1605658370.834911:0:5643:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+[97m00040000:00000001:3.0:1605658370.834914:0:5644:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[91m00040000:00000001:3.0:1605658370.834914:0:5645:0:(qmt_handler.c:56:qmt_get()) Process entered
+[32m00040000:00000001:3.0:1605658370.834915:0:5646:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[33m00040000:00000001:3.0:1605658370.834915:0:5647:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[35m00040000:04000000:3.0:1605658370.834916:0:5648:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+[36m00040000:00000001:3.0:1605658370.834916:0:5649:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+[37m00040000:00000001:3.0:1605658370.834917:0:5650:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[31m00040000:00000001:3.0:1605658370.834918:0:5651:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[92m00040000:00000001:3.0:1605658370.834919:0:5652:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[93m00040000:04000000:3.0:1605658370.834920:0:5653:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+[95m00040000:00000001:3.0:1605658370.834922:0:5654:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[96m00040000:00000001:3.0:1605658370.834922:0:5655:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)
+[0m

--- a/test/llogcolor_files/output-color-single_tid-once
+++ b/test/llogcolor_files/output-color-single_tid-once
@@ -1,0 +1,23 @@
+[32m00040000:00000001:3.0F:1605658370.834898:0:5635:0:(qmt_handler.c:354:qmt_quotactl()) Process entered
+[32m00040000:00000001:3.0:1605658370.834900:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+[32m00040000:00000001:3.0:1605658370.834901:0:5635:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[32m00040000:00000001:3.0:1605658370.834902:0:5635:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[32m00040000:04000000:3.0:1605658370.834903:0:5635:0:(qmt_pool.c:396:qmt_pool_lookup()) type 1 name           (null) index -1
+[32m00040000:00000001:3.0:1605658370.834904:0:5635:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961902080 : -122243747649536 : ffff90d1e8d86800)
+[32m00040000:00000001:3.0:1605658370.834906:0:5635:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[32m00040000:00000001:3.0:1605658370.834909:0:5635:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[32m00040000:00000001:3.0:1605658370.834910:0:5635:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160155296 : -122243549396320 : ffff90d1f4a982a0)
+[32m00040000:04000000:3.0:1605658370.834911:0:5635:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:md-0x0 id:60000 enforced:0 hard:0 soft:0 granted:0 time:0 qunit: 0 edquot:0 may_rel:0 revoke:0 default:no
+[32m00040000:00000001:3.0:1605658370.834914:0:5635:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[32m00040000:00000001:3.0:1605658370.834914:0:5635:0:(qmt_handler.c:56:qmt_get()) Process entered
+[32m00040000:00000001:3.0:1605658370.834915:0:5635:0:(qmt_pool.c:766:qmt_pool_lqe_lookup()) Process entered
+[32m00040000:00000001:3.0:1605658370.834915:0:5635:0:(qmt_pool.c:387:qmt_pool_lookup()) Process entered
+[32m00040000:04000000:3.0:1605658370.834916:0:5635:0:(qmt_pool.c:396:qmt_pool_lookup()) type 2 name           (null) index -1
+[32m00040000:00000001:3.0:1605658370.834916:0:5635:0:(qmt_pool.c:434:qmt_pool_lookup()) Process leaving (rc=18446621829961903616 : -122243747648000 : ffff90d1e8d86e00)
+[32m00040000:00000001:3.0:1605658370.834917:0:5635:0:(lquota_entry.c:330:lqe_locate_find()) Process entered
+[32m00040000:00000001:3.0:1605658370.834918:0:5635:0:(lquota_entry.c:335:lqe_locate_find()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[32m00040000:00000001:3.0:1605658370.834919:0:5635:0:(qmt_pool.c:786:qmt_pool_lqe_lookup()) Process leaving (rc=18446621830160154848 : -122243549396768 : ffff90d1f4a980e0)
+[32m00040000:04000000:3.0:1605658370.834920:0:5635:0:(qmt_handler.c:69:qmt_get()) $$$ fetch settings  qmt:lustre-QMT0000 pool:dt-0x0 id:60000 enforced:1 hard:20480 soft:0 granted:5120 time:0 qunit: 4096 edquot:0 may_rel:0 revoke:0 default:no
+[32m00040000:00000001:3.0:1605658370.834922:0:5635:0:(qmt_handler.c:91:qmt_get()) Process leaving (rc=0 : 0 : 0)
+[32m00040000:00000001:3.0:1605658370.834922:0:5635:0:(qmt_handler.c:484:qmt_quotactl()) Process leaving (rc=0 : 0 : 0)
+[0m

--- a/test/test_llogcolor.py
+++ b/test/test_llogcolor.py
@@ -1,0 +1,100 @@
+"""A test script for llogcolor.
+Set up to simulate calling llogcolor
+from the command line.
+
+The reference files are visually checked,
+and in some cases verified idential to the
+output from the original python2 version of
+llogcolor.
+"""
+
+import pathlib
+import subprocess
+import unittest
+
+llogcolor_path = pathlib.Path("../scripts/llogcolor")
+
+
+def cmp_stdout_to_ref(args, input_files, output_file):
+    """Compare the output from llogcolor
+    to a reference file of an assumed good output.
+    """
+    # run llogcolor, and capture its output
+    cmd = subprocess.run(
+        [llogcolor_path] + args + input_files,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    # check that the output matches the reference
+    with open(output_file, "r") as f:
+        reference_text = f.read()
+        if cmd.stdout.decode() != reference_text:
+            return False
+    return True
+
+
+class TestTextOutput(unittest.TestCase):
+    """Tests that create output and then compare
+    that output to a reference file.
+    """
+
+    # each element will be run as a separate test
+    subtest_params = [
+        {
+            "msg": "read a log file in, and just send it unmodified to stdout",
+            "flags": ["-P", "-C"],
+            "input_files": ["llogcolor_files/input-single_tid-once"],
+            "output_file": "llogcolor_files/input-single_tid-once",
+        },
+        {
+            "msg": (
+                "read a log file in, and send the text to stdout. "
+                "In this case the text includes the terminal color codes "
+                "However, all the lines will have the same color code."
+            ),
+            "flags": ["-P"],
+            "input_files": ["llogcolor_files/input-single_tid-once"],
+            "output_file": "llogcolor_files/output-color-single_tid-once",
+        },
+        {
+            "msg": (
+                "read a log file in, and send the text to stdout. "
+                "assign differnet colors to differnt threads."
+            ),
+            "flags": ["-P"],
+            "input_files": ["llogcolor_files/input-multi_tid-once"],
+            "output_file": "llogcolor_files/output-color-multi_tid-once",
+        },
+        {
+            "msg": (
+                "read a log file in, and send the text to stdout. "
+                "assign differnet colors to differnt threads. "
+                "check that thread gets assigned the same color when "
+                "processed the second time."
+            ),
+            "flags": ["-P"],
+            "input_files": ["llogcolor_files/input-multi_tid-twice"],
+            "output_file": "llogcolor_files/output-color-multi_tid-twice",
+        },
+    ]
+
+    def test_compare_to_reference(self):
+        """Check that llogcolor, when given the proper inputs
+        produces the proper output, by comparing the output
+        to a known reference.
+        """
+        for params in self.subtest_params:
+            with self.subTest(**params):
+                self.assertTrue(
+                    cmp_stdout_to_ref(
+                        params["flags"],
+                        params["input_files"],
+                        params["output_file"],
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
llogcolor is modified so that arguments besides those
from the command line can be used.
This feature is used by its new testing script
test_llogcolor.py.

A test directory is created with a single test script
and sample log input and output files that are used as
references for the tests.

The function next_ansi_color() was removed because it
modifies global state and this is a problem for tests
that expect outputs to match verbatim and run main() more than
once with reloading the module. The functionality of
next_ansi_color() is now in main().