### PR TITLE
Fix bug due to change in lfs output

### DIFF
--- a/scripts/lustre_quota_summary
+++ b/scripts/lustre_quota_summary
@@ -90,6 +90,10 @@ def get_usage(ids, userorgroup, mountpt, obd_uuid):
             # put quota stats in the dictionary, and convert each field
             # to an integer at the same time
             usage[name] = [try_int(x) for x in args]
+
+            # stop the loop once an acceptable line has been processed
+            break
+
     return usage
 
 def get_ids_from_directory(directory, userorgroup):
@@ -103,7 +107,7 @@ def get_ids_from_directory(directory, userorgroup):
         if not os.path.isdir(path):
             continue
         st = os.stat(path)
-        
+
         if (userorgroup == 'user'):
             ident = st.st_uid
         elif (userorgroup == 'group'):


### PR DESCRIPTION
A change in the output of "lfs quota -q <mount>" caused a bug.
lustre_quota_summary incorrectly interpreted a line
in the lfs output to be numerical quota data, which caused
the wrong data to be reported by lustre_quota_summary.
Instead of reporting the amount of bytes used, the user's
uid was incorrectly interpreted as kilobytes used.
The number of inodes used was replaced by the word "file".

In previous versions of lfs there were no lines
after the line with the quota data. The fix is to simply
stop reading input once the correct input has been found.