### PR TITLE
update ldev2pcs for pacemaker 2.X

### DIFF
--- a/scripts/ldev2pcs
+++ b/scripts/ldev2pcs
@@ -20,6 +20,30 @@ def should_skip(line):
         return True
     return False
 
+def get_pacemaker_major_number():
+    '''Get the rpm major number of pacemaker,
+    and return as an int.
+    '''
+    rpm_version = subprocess.check_output(
+        ['rpm', '-q', 'pacemaker']
+    ).strip()
+
+    captured_major_number = re.match(r'pacemaker-(?P<major>\d+).*$', rpm_version)
+
+    return int(captured_major_number.group('major'))
+
+def file_regex_replace(regex, replacement, path):
+    '''Replace all instances of regex with replacement
+    for the the file at path.
+    '''
+    f = open(path, 'r+')
+    text = f.read()
+    text = re.sub(regex, replacement, text)
+    f.seek(0)
+    f.write(text)
+    f.truncate()
+    f.close()
+
 # Assume line in ldev looks like this for zfs:
 #  jet1   jet2   lquake-MGS0000  zfs:jet1-1/mgs
 def process_ldev_line(line):
@@ -102,10 +126,34 @@ def configure_location(resource, nodes, fixed_score_string=None):
             score -= 10
 
 def configure():
-    cmd = 'pcs cluster setup --force --local'
-    cmd += ' --name '+cmdline_args.cluster_name
-    cmd += ' '+cmdline_args.mgmt_node
-    run(cmd)
+    # the syntax for making the corosync.conf
+    # file depends on the pacemaker version
+    pacemaker_major_number = get_pacemaker_major_number()
+    if pacemaker_major_number == 1:
+        cmd = 'pcs cluster setup --force --local'
+        cmd += ' --name '+cmdline_args.cluster_name
+        cmd += ' '+cmdline_args.mgmt_node
+    elif pacemaker_major_number == 2:
+        cmd = 'pcs cluster setup'
+        cmd += ' '+cmdline_args.cluster_name
+        cmd += ' '+cmdline_args.mgmt_node
+        cmd += ' --corosync_conf /etc/corosync/corosync.conf --overwrite'
+    else:
+        raise ValueError(
+            'pacemaker rpm major number must '
+            'be 1 or 2 but is %d' % pacemaker_major_number
+        )
+    if not cmdline_args.no_corosync:
+        run(cmd)
+        if pacemaker_major_number == 2:
+            # set crypto values to none, which are aes256 and sha256 by default
+            # this should be doable using the 'pcs cluster setup'
+            # command, but I haven't been able to make it work
+            file_regex_replace(
+                r'crypto_(cipher|hash): \w+\b',
+                r'crypto_\1: none',
+                '/etc/corosync/corosync.conf'
+            )
     run('pcs cluster start')
     run('pcs property set symmetric-cluster=false')
     run('pcs property set stonith-action=off')
@@ -121,8 +169,12 @@ def configure():
     run('pcs constraint location fence_pm prefers '+cmdline_args.mgmt_node)
 
     for node in all_nodes:
-        run('pcs resource create '+node+' ocf:pacemaker:remote'+' server=e'+node+
-            ' reconnect_interval=60')
+        if pacemaker_major_number == 1:
+            run('pcs resource create '+node+' ocf:pacemaker:remote'+' server=e'+node+
+                ' reconnect_interval=60')
+        if pacemaker_major_number == 2:
+            run('pcs resource create --force '+node+' ocf:pacemaker:remote'+' server=e'+node+
+                ' reconnect_interval=60')
         run('pcs constraint location '+node+' prefers '+cmdline_args.mgmt_node)
 
     for zpool in zpool_order:
@@ -184,6 +236,8 @@ def main():
     parser.add_argument('--fence-ipport', default='10101',
                         help='Powerman server port number (for fence_powerman, default 10101)')
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--no-corosync', action='store_true',
+                        help='Don\'t create a new corosync.conf file.')
     cmdline_args = parser.parse_args()
 
     # turn it into a list, even if there is only one node


### PR DESCRIPTION
The command to make a corosync.conf file, as well as
a resource creation command, have a different syntax for
pacemaker 2.X vs pacemaker 1.X.
Check which version of pacemaker is being used and change the
syntax accordingly.
Additionally, there is an command line option to skip making
a new corosync.conf file.