### PR TITLE
update specfile for lustre_fssync

### DIFF
--- a/lustre-tools-llnl.spec.in
+++ b/lustre-tools-llnl.spec.in
@@ -2,7 +2,7 @@ Summary: Miscellaneous lustre tools from LLNL
 Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Release: 1%{?dist}
-License: GPL-2.0
+License: GPL-2.0 AND GPL-3.0
 Group: System Environment/Base
 URL: https://github.com/llnl/lustre-tools-llnl
 Packager: Christopher J. Morrone <morrone2@llnl.gov>
@@ -30,6 +30,8 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-)
 %doc
+# lustre_fssync is GPL-3.0
+# remaining installed scripts and binaries are GPL-2.0
 %{_sbindir}/*
 %{_mandir}/*/*
 %{_prefix}/lib/ocf/resource.d/llnl/lustre

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -7,7 +7,7 @@
 # Produced at the Lawrence Livermore National Laboratory.
 # LLNL-CODE-468512
 
-dist_sbin_SCRIPTS = lflush lustre_quota_summary zfsobj2fid ldev2pcs llogcolor
+dist_sbin_SCRIPTS = lflush lustre_quota_summary zfsobj2fid ldev2pcs llogcolor lustre_fssync
 
 resourceagentdir = ${prefix}/lib/ocf/resource.d/llnl
 dist_resourceagent_SCRIPTS = lustre zpool


### PR DESCRIPTION
lustre-fssync is GPL-3.0, so we need to advertise that in the RPM.

Add lustre_fssync to the Makefile so it's installed and included in the rpm.

Tested by building an rpm.

Verified lustre_fssync is now pulled into the rpm:
```
[faaland1@rzslic4 branch:b-rpm-license lustre-tools-llnl] $rpm2cpio ~/rpmbuild/RPMS/x86_64/lustre-tools-llnl-1.8.22-1.t4.x86_64.rpm | cpio --list
./usr/lib/.build-id
./usr/lib/.build-id/0d
./usr/lib/.build-id/0d/2c9e50b002889a1a41aa2ecdf4c464538d2f12
./usr/lib/ocf/resource.d/llnl/lustre
./usr/lib/ocf/resource.d/llnl/zpool
./usr/sbin/ldev2pcs
./usr/sbin/lflush
./usr/sbin/llogcolor
./usr/sbin/lpurge
./usr/sbin/lustre_fssync
./usr/sbin/lustre_quota_summary
./usr/sbin/zfsobj2fid
./usr/share/man/man8/lflush.8.gz
./usr/share/man/man8/lpurge.8.gz
177 blocks
```

Verified the license change is reflected:
```
[faaland1@rzslic4 branch:b-rpm-license lustre-tools-llnl] $rpm -qi --package  ~/rpmbuild/RPMS/x86_64/lustre-tools-llnl-1.8.22-1.t4.x86_64.rpm 
Name        : lustre-tools-llnl
Version     : 1.8.22
Release     : 1.t4
Architecture: x86_64
Install Date: (not installed)
Group       : System Environment/Base
Size        : 88163
License     : GPL-2.0 AND GPL-3.0
Signature   : (none)
Source RPM  : lustre-tools-llnl-1.8.22-1.t4.src.rpm
Build Date  : Fri 16 Jun 2023 01:26:21 PM PDT
Build Host  : rzslic4.llnl.gov
Relocations : (not relocatable)
Packager    : Christopher J. Morrone <morrone2@llnl.gov>
URL         : https://github.com/llnl/lustre-tools-llnl
Summary     : Miscellaneous lustre tools from LLNL
Description :
```