### PR TITLE
DRAFT: Add tool convert lfs setstripe output to path ondisk

### DIFF
--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -75,7 +75,7 @@ def objid_to_path(oid_s):
     if oid_m:
         seq_s = 0
         oid = int(oid_s, 16)
-        path_s = f'O/{seq_s[2:]}/d{oid % 32}/{oid}'
+        path_s = f'O/{seq_s}/d{oid % 32}/{oid}'
 
     return path_s
 
@@ -97,8 +97,8 @@ def striping_parser():
             fpath = fid_to_path(lmm_m.group(3))
             print(f'{fname} OST{int(ost):04x} {fpath}')
         elif lmm_simple_m:
-            ost = lmm_m.group(1)
-            fpath = objid_to_path(lmm_m.group(3))
+            ost = lmm_simple_m.group(1)
+            fpath = objid_to_path(lmm_simple_m.group(3))
             print(f'{fname} OST{int(ost):04x} {fpath}')
 
 def main():

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -79,7 +79,7 @@ def striping_parser():
             line_type = 'lmm'
             ost = lmm_m.group(2)
             fpath = fid_to_path(lmm_m.group(3))
-            print(f'{fname} OST{int(ost):04} {fpath}')
+            print(f'{fname} OST{int(ost):04x} {fpath}')
 
 def main():
     arg_parser = make_arg_parser()

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -81,7 +81,7 @@ def objid_to_path(oid_s):
 
 fname_re = re.compile("^([^\s]+)$")
 lmm_object_pfl_re = re.compile(' +- ([0-9]+): +. l_ost_idx: ([0-9]+), l_fid: .(0x[0-9a-f]+:0x[0-9a-f]+:0x[0-9a-f]+). .')
-lmm_object_simple_re = re.compile(' +- ([0-9]+) ([0-9]+) (0x[0-9a-f]+) (0x[0-9a-f]+)')
+lmm_object_simple_re = re.compile(' +([0-9]+) +([0-9]+) +(0x[0-9a-f]+) +(0*x*[0-9a-f]+)')
 
 def striping_parser():
     fname = None

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -67,8 +67,8 @@ def fid_to_path(fid):
 
     return path_s
 
-hex_re = re.compile('0x[0-9a-f]+)')
-def objid_to_path(oid_s)
+hex_re = re.compile('(0x[0-9a-f]+)')
+def objid_to_path(oid_s):
     path_s = None
     oid_m = hex_re.match(oid_s)
 

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -68,14 +68,19 @@ def fid_to_path(fid):
     return path_s
 
 hex_re = re.compile('(0x[0-9a-f]+)')
-def objid_to_path(oid_s):
+def objid_to_path(oid_s, group_s):
     path_s = None
     oid_m = hex_re.match(oid_s)
+    group_m = hex_re.match(group_s)
 
     if oid_m:
         seq_s = 0
         oid = int(oid_s, 16)
-        path_s = f'O/{seq_s}/d{oid % 32}/{oid}'
+        if group_m:
+            group = group_s[2:]
+        else:
+            group = "0"
+        path_s = f'O/{group}/d{oid % 32}/{oid}'
 
     return path_s
 
@@ -98,7 +103,9 @@ def striping_parser():
             print(f'{fname} OST{int(ost):04x} {fpath}')
         elif lmm_simple_m:
             ost = lmm_simple_m.group(1)
-            fpath = objid_to_path(lmm_simple_m.group(3))
+            group = lmm_simple_m.group(4)
+            objid = lmm_simple_m.group(3)
+            fpath = objid_to_path(objid, group)
             print(f'{fname} OST{int(ost):04x} {fpath}')
 
 def main():

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -28,6 +28,11 @@
 #   - 0: { l_ost_idx: 4, l_fid: [0x480000403:0x3ab09:0x0] }
 # emit
 # test.pfl.3 OST0004 /mnt/olaf/480000403/d9/240393
+#
+# "lfs getstripe" output for a non-pfl ("simple") file like this
+# is also parsed.
+#         obdidx           objid           objid           group
+#              1       174345597      0xa644d7d      0x2c0000400
 
 import argparse
 import sys
@@ -62,23 +67,38 @@ def fid_to_path(fid):
 
     return path_s
 
+hex_re = re.compile('0x[0-9a-f]+)')
+def objid_to_path(oid_s)
+    path_s = None
+    oid_m = hex_re.match(oid_s)
+
+    if oid_m:
+        seq_s = 0
+        oid = int(oid_s, 16)
+        path_s = f'O/{seq_s[2:]}/d{oid % 32}/{oid}'
+
+    return path_s
+
 fname_re = re.compile("^([^\s]+)$")
-lmm_object_re = re.compile(' +- ([0-9]+): +. l_ost_idx: ([0-9]+), l_fid: .(0x[0-9a-f]+:0x[0-9a-f]+:0x[0-9a-f]+). .')
+lmm_object_pfl_re = re.compile(' +- ([0-9]+): +. l_ost_idx: ([0-9]+), l_fid: .(0x[0-9a-f]+:0x[0-9a-f]+:0x[0-9a-f]+). .')
+lmm_object_simple_re = re.compile(' +- ([0-9]+) ([0-9]+) (0x[0-9a-f]+) (0x[0-9a-f]+)')
 
 def striping_parser():
     fname = None
     for line in sys.stdin:
-        line_type = None
         fname_m = fname_re.match(line)
-        lmm_m = lmm_object_re.match(line)
+        lmm_m = lmm_object_pfl_re.match(line)
+        lmm_simple_m = lmm_object_simple_re.match(line)
 
         if fname_m:
-            line_type = 'name'
             fname = line.rstrip()
         elif lmm_m:
-            line_type = 'lmm'
             ost = lmm_m.group(2)
             fpath = fid_to_path(lmm_m.group(3))
+            print(f'{fname} OST{int(ost):04x} {fpath}')
+        elif lmm_simple_m:
+            ost = lmm_m.group(1)
+            fpath = objid_to_path(lmm_m.group(3))
             print(f'{fname} OST{int(ost):04x} {fpath}')
 
 def main():

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by Olaf Faaland <faaland1@llnl.gov>
+# LLNL-CODE-468512
+#
+# This file is part of lustre-tools-llnl.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License (as published by the
+# Free Software Foundation) version 2, dated June 1991.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# terms and conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+# Given the output of "lfs getstripe", and a mountpoint, give
+# the paths to the OST objects assuming a ZFS-based OST.
+#
+# For example, given mountpoint "/mnt/olaf" and input
+#   test.pfl.3
+#   - 0: { l_ost_idx: 4, l_fid: [0x480000403:0x3ab09:0x0] }
+# emit
+# test.pfl.3 OST0004 /mnt/olaf/480000403/d9/240393
+
+import argparse
+import sys
+import subprocess
+import re
+
+def from_bytes(b):
+    return sum(b[i] << i * 8 for i in range(len(b)))
+
+def make_arg_parser():
+    description = (
+        "Given the mountpoint for a zfs dataset for a Lustre OST as an argument"
+        "and the output of 'lfs getstripe' on stdin, this script will give "
+        "the paths to the stripe objects under that mountpoint."
+    )
+    arg_parser = argparse.ArgumentParser(description=description)
+    arg_parser.add_argument("mountpoint", help="mountpoint the name of the OST's zfs dataset")
+
+    return arg_parser
+
+fid_re = re.compile('(0x[0-9a-f]+):(0x[0-9a-f]+):(0x[0-9a-f]+)')
+def fid_to_path(fid):
+    path_s = None
+    fid_m = fid_re.match(fid)
+
+    if fid_m:
+        seq_s = fid_m.group(1)
+        oid_s = fid_m.group(2)
+        ver_s = fid_m.group(3)
+        oid = int(oid_s, 16)
+        path_s = f'O/{seq_s[2:]}/d{oid % 32}/{oid}'
+
+    return path_s
+
+fname_re = re.compile("^([^\s]+)$")
+lmm_object_re = re.compile(' +- ([0-9]+): +. l_ost_idx: ([0-9]+), l_fid: .(0x[0-9a-f]+:0x[0-9a-f]+:0x[0-9a-f]+). .')
+
+def striping_parser():
+    fname = None
+    for line in sys.stdin:
+        line_type = None
+        fname_m = fname_re.match(line)
+        lmm_m = lmm_object_re.match(line)
+
+        if fname_m:
+            line_type = 'name'
+            fname = line.rstrip()
+        elif lmm_m:
+            line_type = 'lmm'
+            ost = lmm_m.group(2)
+            fpath = fid_to_path(lmm_m.group(3))
+            print(f'{fname} OST{int(ost):04} {fpath}')
+
+def main():
+    arg_parser = make_arg_parser()
+    args = arg_parser.parse_args()
+
+    striping_parser()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -85,8 +85,8 @@ def objid_to_path(oid_s, group_s):
     return path_s
 
 fname_re = re.compile("^([^\s]+)$")
-lmm_object_pfl_re = re.compile(' +- ([0-9]+): +. l_ost_idx: ([0-9]+), l_fid: .(0x[0-9a-f]+:0x[0-9a-f]+:0x[0-9a-f]+). .')
-lmm_object_simple_re = re.compile(' +([0-9]+) +([0-9]+) +(0x[0-9a-f]+) +(0*x*[0-9a-f]+)')
+lmm_object_pfl_re = re.compile('\s+-\s([0-9]+):\s+.\sl_ost_idx:\s([0-9]+),\sl_fid:\s.(0x[0-9a-f]+:0x[0-9a-f]+:0x[0-9a-f]+).\s.')
+lmm_object_simple_re = re.compile('\s+([0-9]+)\s +([0-9]+)\s +(0x[0-9a-f]+)\s +(0*x*[0-9a-f]+)')
 
 def striping_parser():
     fname = None

--- a/scripts/lustre_stripe_to_paths
+++ b/scripts/lustre_stripe_to_paths
@@ -39,6 +39,8 @@ import sys
 import subprocess
 import re
 
+args = None
+
 def from_bytes(b):
     return sum(b[i] << i * 8 for i in range(len(b)))
 
@@ -106,9 +108,11 @@ def striping_parser():
             group = lmm_simple_m.group(4)
             objid = lmm_simple_m.group(3)
             fpath = objid_to_path(objid, group)
-            print(f'{fname} OST{int(ost):04x} {fpath}')
+            print(f'{fname} OST{int(ost):04x} {args.mountpoint}/{fpath}')
 
 def main():
+    global args
+
     arg_parser = make_arg_parser()
     args = arg_parser.parse_args()
 


### PR DESCRIPTION
Convert from lfs getstripe output, to path of objects on disk when looking at a zfs snapshot of the OST.

$ lfs getstripe test.pfl.4 | grep -e '^[a-z]' -e lcme_id -e l_ost_idx test.pfl.4
    lcme_id:             1
    lcme_id:             2
      - 0: { l_ost_idx: 0, l_fid: [0x380000402:0x3ab02:0x0] }
    lcme_id:             3
      - 0: { l_ost_idx: 4, l_fid: [0x480000403:0x3ab02:0x0] }
      - 1: { l_ost_idx: 5, l_fid: [0x4c0000404:0x3ab02:0x0] }
      ...

to

OST0000 /mnt/olaf/O/380000402/d2/240386
OST0004 /mnt/olaf/O/480000403/d2/240386
OST0005 /mnt/olaf/O/4c0000404/d2/240386